### PR TITLE
Avoid copy in itoa and write directly to the target buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,29 +58,28 @@ Since these log lines ar long, please scroll horizontally to the right to see al
 ## Benchmark result
 
 ```
-$ go test -count=10 -bench . -benchmem
-BenchmarkLTSVLog-2               2000000               700 ns/op             238 B/op          3 allocs/op
-BenchmarkLTSVLog-2               2000000               705 ns/op             238 B/op          3 allocs/op
-BenchmarkLTSVLog-2               2000000               702 ns/op             238 B/op          3 allocs/op
-BenchmarkLTSVLog-2               2000000               703 ns/op             238 B/op          3 allocs/op
-BenchmarkLTSVLog-2               2000000               704 ns/op             238 B/op          3 allocs/op
-BenchmarkLTSVLog-2               2000000               706 ns/op             238 B/op          3 allocs/op
-BenchmarkLTSVLog-2               2000000               714 ns/op             238 B/op          3 allocs/op
-BenchmarkLTSVLog-2               2000000               705 ns/op             238 B/op          3 allocs/op
-BenchmarkLTSVLog-2               2000000               703 ns/op             238 B/op          3 allocs/op
-BenchmarkLTSVLog-2               2000000               703 ns/op             238 B/op          3 allocs/op
-BenchmarkStandardLog-2           2000000               787 ns/op             274 B/op          3 allocs/op
-BenchmarkStandardLog-2           2000000               790 ns/op             274 B/op          3 allocs/op
-BenchmarkStandardLog-2           2000000               790 ns/op             274 B/op          3 allocs/op
-BenchmarkStandardLog-2           2000000               790 ns/op             274 B/op          3 allocs/op
-BenchmarkStandardLog-2           2000000               794 ns/op             274 B/op          3 allocs/op
-BenchmarkStandardLog-2           2000000               790 ns/op             274 B/op          3 allocs/op
-BenchmarkStandardLog-2           2000000               790 ns/op             274 B/op          3 allocs/op
-BenchmarkStandardLog-2           2000000               793 ns/op             274 B/op          3 allocs/op
-BenchmarkStandardLog-2           2000000               792 ns/op             274 B/op          3 allocs/op
-BenchmarkStandardLog-2           2000000               789 ns/op             274 B/op          3 allocs/op
+BenchmarkLTSVLog-2       	 2000000	       683 ns/op	     238 B/op	       3 allocs/op
+BenchmarkLTSVLog-2       	 2000000	       677 ns/op	     238 B/op	       3 allocs/op
+BenchmarkLTSVLog-2       	 2000000	       674 ns/op	     238 B/op	       3 allocs/op
+BenchmarkLTSVLog-2       	 2000000	       677 ns/op	     238 B/op	       3 allocs/op
+BenchmarkLTSVLog-2       	 2000000	       676 ns/op	     238 B/op	       3 allocs/op
+BenchmarkLTSVLog-2       	 2000000	       673 ns/op	     238 B/op	       3 allocs/op
+BenchmarkLTSVLog-2       	 2000000	       673 ns/op	     238 B/op	       3 allocs/op
+BenchmarkLTSVLog-2       	 2000000	       675 ns/op	     238 B/op	       3 allocs/op
+BenchmarkLTSVLog-2       	 2000000	       676 ns/op	     238 B/op	       3 allocs/op
+BenchmarkLTSVLog-2       	 2000000	       675 ns/op	     238 B/op	       3 allocs/op
+BenchmarkStandardLog-2   	 2000000	       808 ns/op	     274 B/op	       3 allocs/op
+BenchmarkStandardLog-2   	 2000000	       803 ns/op	     274 B/op	       3 allocs/op
+BenchmarkStandardLog-2   	 2000000	       804 ns/op	     274 B/op	       3 allocs/op
+BenchmarkStandardLog-2   	 2000000	       804 ns/op	     274 B/op	       3 allocs/op
+BenchmarkStandardLog-2   	 2000000	       805 ns/op	     274 B/op	       3 allocs/op
+BenchmarkStandardLog-2   	 2000000	       806 ns/op	     274 B/op	       3 allocs/op
+BenchmarkStandardLog-2   	 2000000	       805 ns/op	     274 B/op	       3 allocs/op
+BenchmarkStandardLog-2   	 2000000	       807 ns/op	     274 B/op	       3 allocs/op
+BenchmarkStandardLog-2   	 2000000	       804 ns/op	     274 B/op	       3 allocs/op
+BenchmarkStandardLog-2   	 2000000	       807 ns/op	     274 B/op	       3 allocs/op
 PASS
-ok      github.com/hnakamur/ltsvlog     45.224s
+ok  	github.com/hnakamur/ltsvlog	44.867s
 ```
 
 ## License


### PR DESCRIPTION
```
$ benchstat old-add-time.log new-add-time.log
name           old time/op    new time/op    delta
LTSVLog-2         712ns ± 1%     675ns ± 0%  -5.19%  (p=0.000 n=10+9)
StandardLog-2     806ns ± 0%     805ns ± 0%    ~     (p=0.163 n=9+10)

name           old alloc/op   new alloc/op   delta
LTSVLog-2          238B ± 0%      238B ± 0%    ~     (all equal)
StandardLog-2      274B ± 0%      274B ± 0%    ~     (all equal)

name           old allocs/op  new allocs/op  delta
LTSVLog-2          3.00 ± 0%      3.00 ± 0%    ~     (all equal)
StandardLog-2      3.00 ± 0%      3.00 ± 0%    ~     (all equal)
```