### PR TITLE
Add WrapErr to ErrorEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/hnakamur/ltsvlog"
 )
@@ -34,7 +35,13 @@ func main() {
 }
 
 func a() error {
-	return b()
+	err := b()
+	if err != nil {
+		return ltsvlog.WrapErr(err, func(err error) error {
+			return fmt.Errorf("add explanation here, err=%v", err)
+		})
+	}
+	return nil
 }
 
 func b() error {
@@ -45,9 +52,9 @@ func b() error {
 An example output:
 
 ```
-time:2017-05-21T05:19:11.256860Z	level:Debug	msg:This is a debug message	str:foo	int:234
-time:2017-05-21T05:19:11.256887Z	level:Info	float1:3.14
-time:2017-05-21T05:19:11.256926Z	level:Error	err:some error	key1:value1	stack:[main.b(0x0, 0x0) /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/main.go:28 +0xc8],[main.a(0xc42001a240, 0x4c5d6e) /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/main.go:24 +0x22],[main.main() /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/main.go:17 +0x11e]
+time:2017-06-01T16:52:33.959833Z	level:Debug	msg:This is a debug message	str:foo	int:234
+time:2017-06-01T16:52:33.959862Z	level:Info	float1:3.14
+time:2017-06-01T16:52:33.959914Z	level:Error	err:add explanation here, err=some error	key1:value1	stack:[main.b(0x2000, 0x38) /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/main.go:35 +0xc8],[main.a(0xc42001a240, 0x4c6e2e) /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/main.go:25 +0x22],[main.main() /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/main.go:18 +0x11e]
 ```
 
 Since these log lines ar long, please scroll horizontally to the right to see all the output.

--- a/error_event.go
+++ b/error_event.go
@@ -53,7 +53,7 @@ func Err(err error) *ErrorEvent {
 func WrapErr(err error, wrapper func(err error) error) *ErrorEvent {
 	e, ok := err.(*ErrorEvent)
 	if !ok {
-		return Err(err)
+		e = Err(err)
 	}
 
 	e.error = wrapper(e.error)

--- a/error_event.go
+++ b/error_event.go
@@ -56,7 +56,9 @@ func WrapErr(err error, wrapper func(err error) error) *ErrorEvent {
 		e = Err(err)
 	}
 
-	e.error = wrapper(e.error)
+	if wrapper != nil {
+		e.error = wrapper(e.error)
+	}
 	return e
 }
 

--- a/error_event.go
+++ b/error_event.go
@@ -234,12 +234,11 @@ func (e *ErrorEvent) Error() string {
 	return e.error.Error()
 }
 
-// ErrorWithValues returns the error string with labeled values.
-func (e *ErrorEvent) ErrorWithValues() string {
-	buf := make([]byte, 0, 8192+len(e.buf))
+// AppendErrorWithValues appends the error string with labeled values to a byte buffer.
+func (e *ErrorEvent) AppendErrorWithValues(buf []byte) []byte {
 	buf = append(buf, "err:"...)
 	buf = append(buf, escape(e.Error())...)
-	return string(append(buf, e.buf...))
+	return append(buf, e.buf...)
 }
 
 // OriginalError returns the original error.

--- a/error_event.go
+++ b/error_event.go
@@ -9,14 +9,6 @@ import (
 	"time"
 )
 
-var errorEventPool = &sync.Pool{
-	New: func() interface{} {
-		return &ErrorEvent{
-			buf: make([]byte, 8192),
-		}
-	},
-}
-
 // ErrorEvent is an error with label and value pairs.
 // *ErrroEvent implements the error interface so you can
 // return *ErrorEvent as an error.
@@ -42,11 +34,11 @@ type ErrorEvent struct {
 
 // Err creates an ErrorEvent with the specified error.
 func Err(err error) *ErrorEvent {
-	e := errorEventPool.Get().(*ErrorEvent)
-	e.error = err
-	e.originalErr = err
-	e.buf = e.buf[:0]
-	return e
+	return &ErrorEvent{
+		error:       err,
+		originalErr: err,
+		buf:         make([]byte, 0, 8192),
+	}
 }
 
 // WrapErr wraps an ErrorEvent or a plain error and returns a new error.

--- a/example_test.go
+++ b/example_test.go
@@ -2,6 +2,7 @@ package ltsvlog_test
 
 import (
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/hnakamur/ltsvlog"
@@ -48,7 +49,14 @@ func ExampleLTSVLogger_Err() {
 		return ltsvlog.Err(errors.New("some error")).String("key1", "value1").Stack("")
 	}
 	a := func() error {
-		return b()
+		err := b()
+		if err != nil {
+			return ltsvlog.WrapErr(err, func(err error) error {
+				return fmt.Errorf("add explanation here, err=%v", err)
+			})
+		}
+		return nil
+
 	}
 	err := a()
 	if err != nil {
@@ -56,7 +64,7 @@ func ExampleLTSVLogger_Err() {
 	}
 
 	// Output example:
-	// time:2017-05-20T19:29:59.707525Z	level:Error	err:some error	key1:value1	stack:[main.b(0x0, 0x0) /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/err/main.go:21 +0xc8],[main.a(0xc420016200, 0xc4200001a0) /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/err/main.go:17 +0x22],[main.main() /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/err/main.go:10 +0x22]
+	// time:2017-06-01T16:52:33.959914Z	level:Error	err:add explanation here, err=some error	key1:value1	stack:[main.b(0x2000, 0x38) /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/main.go:35 +0xc8],[main.a(0xc42001a240, 0x4c6e2e) /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/main.go:25 +0x22],[main.main() /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/main.go:18 +0x11e]
 	// Output:
 
 	// Actually we don't test the results.

--- a/log.go
+++ b/log.go
@@ -266,7 +266,6 @@ func (l *LTSVLogger) Err(err error) {
 	buf = errorEvent.AppendErrorWithValues(buf)
 	buf = append(buf, '\n')
 	_, _ = l.writer.Write(buf)
-	errorEventPool.Put(errorEvent)
 }
 
 func (l *LTSVLogger) log(level string, lv ...LV) {

--- a/log.go
+++ b/log.go
@@ -262,7 +262,7 @@ func (l *LTSVLogger) Err(err error) {
 		errorEvent = Err(err)
 	}
 	buf := make([]byte, 0, 8192)
-	buf = l.appendPrefixFunc(buf[:0], "Error")
+	buf = l.appendPrefixFunc(buf, "Error")
 	buf = errorEvent.AppendErrorWithValues(buf)
 	buf = append(buf, '\n')
 	_, _ = l.writer.Write(buf)

--- a/log.go
+++ b/log.go
@@ -261,10 +261,9 @@ func (l *LTSVLogger) Err(err error) {
 	if !ok {
 		errorEvent = Err(err)
 	}
-	errStr := errorEvent.ErrorWithValues()
-	buf := make([]byte, 0, 64+len(errStr))
+	buf := make([]byte, 0, 8192)
 	buf = l.appendPrefixFunc(buf[:0], "Error")
-	buf = append(buf, errStr...)
+	buf = errorEvent.AppendErrorWithValues(buf)
 	buf = append(buf, '\n')
 	_, _ = l.writer.Write(buf)
 	errorEventPool.Put(errorEvent)

--- a/log.go
+++ b/log.go
@@ -261,9 +261,10 @@ func (l *LTSVLogger) Err(err error) {
 	if !ok {
 		errorEvent = Err(err)
 	}
-	buf := make([]byte, 8192)
+	errStr := errorEvent.ErrorWithValues()
+	buf := make([]byte, 0, 64+len(errStr))
 	buf = l.appendPrefixFunc(buf[:0], "Error")
-	buf = append(buf, errorEvent.buf...)
+	buf = append(buf, errStr...)
 	buf = append(buf, '\n')
 	_, _ = l.writer.Write(buf)
 	errorEventPool.Put(errorEvent)


### PR DESCRIPTION
This pull request causes a performance degradation, but it's needed for ErrorEvent
to be used without calling ltsvlog.Logger.Err.

```
name                      old time/op    new time/op    delta
Info-2                      1.64µs ± 1%    1.59µs ± 1%    -2.86%  (p=0.000 n=10+10)
ErrWithStackAndUTCTime-2    18.6µs ± 8%    21.6µs ± 2%   +16.09%  (p=0.000 n=10+10)
ErrWithStack-2              17.8µs ± 5%    21.3µs ± 3%   +19.54%  (p=0.000 n=10+10)
ErrWithUTCTime-2            5.54µs ± 4%    7.24µs ± 2%   +30.80%  (p=0.000 n=10+10)

name                      old alloc/op   new alloc/op   delta
Info-2                       0.00B          0.00B           ~     (all equal)
ErrWithStackAndUTCTime-2    8.26kB ± 0%   16.53kB ± 0%  +100.16%  (p=0.000 n=10+10)
ErrWithStack-2              8.26kB ± 0%   16.53kB ± 0%  +100.17%  (p=0.000 n=10+10)
ErrWithUTCTime-2            8.21kB ± 0%   16.46kB ± 0%  +100.57%  (p=0.000 n=10+10)

name                      old allocs/op  new allocs/op  delta
Info-2                        0.00           0.00           ~     (all equal)
ErrWithStackAndUTCTime-2      3.00 ± 0%      5.00 ± 0%   +66.67%  (p=0.000 n=10+10)
ErrWithStack-2                3.00 ± 0%      5.00 ± 0%   +66.67%  (p=0.000 n=10+10)
ErrWithUTCTime-2              2.00 ± 0%      4.00 ± 0%  +100.00%  (p=0.000 n=10+10)
```