### PR TITLE
Use append float

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,8 +1,10 @@
 package ltsvlog_test
 
 import (
+	"bytes"
 	"errors"
 	"io/ioutil"
+	"math"
 	"os"
 	"testing"
 	"time"
@@ -74,5 +76,21 @@ func BenchmarkErrWithUTCTime(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		err = run()
 		logger.Err(err)
+	}
+}
+
+func BenchmarkEvent_Float32(b *testing.B) {
+	buf := new(bytes.Buffer)
+	logger := ltsvlog.NewLTSVLogger(buf, true, ltsvlog.SetTimeLabel(""))
+	for i := 0; i < b.N; i++ {
+		logger.Info().Float32("max_float32", math.MaxFloat32).Float32("smallest_nonzero_float32", math.SmallestNonzeroFloat32).Log()
+	}
+}
+
+func BenchmarkEvent_Float64(b *testing.B) {
+	buf := new(bytes.Buffer)
+	logger := ltsvlog.NewLTSVLogger(buf, true, ltsvlog.SetTimeLabel(""))
+	for i := 0; i < b.N; i++ {
+		logger.Info().Float64("max_float64", math.MaxFloat64).Float64("smallest_nonzero_float64", math.SmallestNonzeroFloat64).Log()
 	}
 }

--- a/error.go
+++ b/error.go
@@ -182,7 +182,7 @@ func (e *Error) Float32(label string, value float32) *Error {
 	e.buf = append(e.buf, '\t')
 	e.buf = append(e.buf, label...)
 	e.buf = append(e.buf, ':')
-	e.buf = append(e.buf, strconv.FormatFloat(float64(value), 'g', -1, 32)...)
+	e.buf = strconv.AppendFloat(e.buf, float64(value), 'g', -1, 32)
 	return e
 }
 
@@ -191,7 +191,7 @@ func (e *Error) Float64(label string, value float64) *Error {
 	e.buf = append(e.buf, '\t')
 	e.buf = append(e.buf, label...)
 	e.buf = append(e.buf, ':')
-	e.buf = append(e.buf, strconv.FormatFloat(value, 'g', -1, 64)...)
+	e.buf = strconv.AppendFloat(e.buf, value, 'g', -1, 64)
 	return e
 }
 

--- a/event.go
+++ b/event.go
@@ -167,7 +167,7 @@ func (e *Event) Float32(label string, value float32) *Event {
 	}
 	e.buf = append(e.buf, label...)
 	e.buf = append(e.buf, ':')
-	e.buf = append(e.buf, strconv.FormatFloat(float64(value), 'g', -1, 32)...)
+	e.buf = strconv.AppendFloat(e.buf, float64(value), 'g', -1, 32)
 	e.buf = append(e.buf, '\t')
 	return e
 }
@@ -179,7 +179,7 @@ func (e *Event) Float64(label string, value float64) *Event {
 	}
 	e.buf = append(e.buf, label...)
 	e.buf = append(e.buf, ':')
-	e.buf = append(e.buf, strconv.FormatFloat(value, 'g', -1, 64)...)
+	e.buf = strconv.AppendFloat(e.buf, value, 'g', -1, 64)
 	e.buf = append(e.buf, '\t')
 	return e
 }


### PR DESCRIPTION
```
go test -count=10 -run=NONE -bench=BenchmarkEvent_Float -benchmem -cpuprofile=cpu-old.prof | tee old.log
goos: linux
goarch: amd64
pkg: github.com/hnakamur/ltsvlog
BenchmarkEvent_Float32-2   	 2000000	       692 ns/op	     227 B/op	       4 allocs/op
BenchmarkEvent_Float32-2   	 2000000	       708 ns/op	     227 B/op	       4 allocs/op
BenchmarkEvent_Float32-2   	 2000000	       695 ns/op	     227 B/op	       4 allocs/op
BenchmarkEvent_Float32-2   	 2000000	       723 ns/op	     227 B/op	       4 allocs/op
BenchmarkEvent_Float32-2   	 2000000	       698 ns/op	     227 B/op	       4 allocs/op
BenchmarkEvent_Float32-2   	 2000000	       706 ns/op	     227 B/op	       4 allocs/op
BenchmarkEvent_Float32-2   	 2000000	       713 ns/op	     227 B/op	       4 allocs/op
BenchmarkEvent_Float32-2   	 2000000	       691 ns/op	     227 B/op	       4 allocs/op
BenchmarkEvent_Float32-2   	 2000000	       697 ns/op	     227 B/op	       4 allocs/op
BenchmarkEvent_Float32-2   	 2000000	       697 ns/op	     227 B/op	       4 allocs/op
BenchmarkEvent_Float64-2   	 2000000	       685 ns/op	     269 B/op	       4 allocs/op
BenchmarkEvent_Float64-2   	 2000000	       676 ns/op	     269 B/op	       4 allocs/op
BenchmarkEvent_Float64-2   	 2000000	       668 ns/op	     269 B/op	       4 allocs/op
BenchmarkEvent_Float64-2   	 2000000	       677 ns/op	     269 B/op	       4 allocs/op
BenchmarkEvent_Float64-2   	 2000000	       671 ns/op	     269 B/op	       4 allocs/op
BenchmarkEvent_Float64-2   	 2000000	       676 ns/op	     269 B/op	       4 allocs/op
BenchmarkEvent_Float64-2   	 2000000	       655 ns/op	     269 B/op	       4 allocs/op
BenchmarkEvent_Float64-2   	 2000000	       678 ns/op	     269 B/op	       4 allocs/op
BenchmarkEvent_Float64-2   	 2000000	       678 ns/op	     269 B/op	       4 allocs/op
BenchmarkEvent_Float64-2   	 2000000	       669 ns/op	     269 B/op	       4 allocs/op
PASS
ok  	github.com/hnakamur/ltsvlog	41.864s

go test -count=10 -run=NONE -bench=BenchmarkEvent_Float -benchmem -cpuprofile=cpu-new.prof | tee new.log
goos: linux
goarch: amd64
pkg: github.com/hnakamur/ltsvlog
BenchmarkEvent_Float32-2   	 3000000	       547 ns/op	     190 B/op	       0 allocs/op
BenchmarkEvent_Float32-2   	 3000000	       538 ns/op	     190 B/op	       0 allocs/op
BenchmarkEvent_Float32-2   	 3000000	       541 ns/op	     190 B/op	       0 allocs/op
BenchmarkEvent_Float32-2   	 3000000	       532 ns/op	     190 B/op	       0 allocs/op
BenchmarkEvent_Float32-2   	 3000000	       541 ns/op	     190 B/op	       0 allocs/op
BenchmarkEvent_Float32-2   	 3000000	       536 ns/op	     190 B/op	       0 allocs/op
BenchmarkEvent_Float32-2   	 3000000	       539 ns/op	     190 B/op	       0 allocs/op
BenchmarkEvent_Float32-2   	 3000000	       533 ns/op	     190 B/op	       0 allocs/op
BenchmarkEvent_Float32-2   	 3000000	       534 ns/op	     190 B/op	       0 allocs/op
BenchmarkEvent_Float32-2   	 3000000	       537 ns/op	     190 B/op	       0 allocs/op
BenchmarkEvent_Float64-2   	 3000000	       496 ns/op	     220 B/op	       0 allocs/op
BenchmarkEvent_Float64-2   	 3000000	       510 ns/op	     220 B/op	       0 allocs/op
BenchmarkEvent_Float64-2   	 3000000	       506 ns/op	     220 B/op	       0 allocs/op
BenchmarkEvent_Float64-2   	 3000000	       508 ns/op	     220 B/op	       0 allocs/op
BenchmarkEvent_Float64-2   	 3000000	       506 ns/op	     220 B/op	       0 allocs/op
BenchmarkEvent_Float64-2   	 3000000	       510 ns/op	     220 B/op	       0 allocs/op
BenchmarkEvent_Float64-2   	 3000000	       508 ns/op	     220 B/op	       0 allocs/op
BenchmarkEvent_Float64-2   	 3000000	       509 ns/op	     220 B/op	       0 allocs/op
BenchmarkEvent_Float64-2   	 3000000	       506 ns/op	     220 B/op	       0 allocs/op
BenchmarkEvent_Float64-2   	 3000000	       504 ns/op	     220 B/op	       0 allocs/op
PASS
ok  	github.com/hnakamur/ltsvlog	42.029s

benchstat old.log new.log | tee stat.log
name             old time/op    new time/op    delta
Event_Float32-2     702ns ± 3%     538ns ± 2%   -23.39%  (p=0.000 n=10+10)
Event_Float64-2     675ns ± 1%     507ns ± 1%   -24.86%  (p=0.000 n=9+9)

name             old alloc/op   new alloc/op   delta
Event_Float32-2      227B ± 0%      190B ± 0%   -16.30%  (p=0.000 n=10+10)
Event_Float64-2      269B ± 0%      220B ± 0%   -18.22%  (p=0.000 n=10+10)

name             old allocs/op  new allocs/op  delta
Event_Float32-2      4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Event_Float64-2      4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
```
