### PR TITLE
Optimize stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ An example output:
 ```
 time:2017-06-01T16:52:33.959833Z	level:Debug	msg:This is a debug message	str:foo	int:234
 time:2017-06-01T16:52:33.959862Z	level:Info	float1:3.14
-time:2017-06-01T16:52:33.959914Z	level:Error	err:add explanation here, err=some error       key1:value1     stack:main.b /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/main.go:43,main.a /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/main.go:33,main.main /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/main.go:21,runtime.main /usr/local/go/src/runtime/proc.go:194,runtime.goexit /usr/local/go/src/runtime/asm_amd64.s:2338
+time:2017-06-01T16:52:33.959914Z	level:Error	err:add explanation here, err=some error       key1:value1     stack:main.b github.com/hnakamur/ltsvlog/example/main.go:43,main.a github.com/hnakamur/ltsvlog/example/main.go:33,main.main github.com/hnakamur/ltsvlog/example/main.go:21,runtime.main runtime/proc.go:194,runtime.goexit runtime/asm_amd64.s:2338
 ```
 
 Since these log lines ar long, please scroll horizontally to the right to see all the output.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ An example output:
 ```
 time:2017-06-01T16:52:33.959833Z	level:Debug	msg:This is a debug message	str:foo	int:234
 time:2017-06-01T16:52:33.959862Z	level:Info	float1:3.14
-time:2017-06-01T16:52:33.959914Z	level:Error	err:add explanation here, err=some error	key1:value1	stack:[main.b(0x2000, 0x38) /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/main.go:35 +0xc8],[main.a(0xc42001a240, 0x4c6e2e) /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/main.go:25 +0x22],[main.main() /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/main.go:18 +0x11e]
+time:2017-06-01T16:52:33.959914Z	level:Error	err:add explanation here, err=some error       key1:value1     stack:main.b /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/main.go:43,main.a /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/main.go:33,main.main /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/main.go:21,runtime.main /usr/local/go/src/runtime/proc.go:194,runtime.goexit /usr/local/go/src/runtime/asm_amd64.s:2338
 ```
 
 Since these log lines ar long, please scroll horizontally to the right to see all the output.

--- a/error_test.go
+++ b/error_test.go
@@ -218,7 +218,7 @@ func TestError_Stack(t *testing.T) {
 	logger := NewLTSVLogger(buf, true, SetTimeLabel(""))
 	logger.Err(Err(errors.New("some error")).Stack(""))
 	got := buf.String()
-	wantRegex := "^level:Error\terr:some error\tstack:\\[github.com/hnakamur/ltsvlog\\.TestError_Stack\\(0x[0-9a-f]+\\) /.*/src/github\\.com/hnakamur/ltsvlog/error_test.go:\\d+ \\+0x[0-9a-f]+\\],.*\n$"
+	wantRegex := "^level:Error\terr:some error\tstack:github.com/hnakamur/ltsvlog\\.TestError_Stack github\\.com/hnakamur/ltsvlog/error_test.go:\\d+,.*\n$"
 	matched, err := regexp.MatchString(wantRegex, got)
 	if err != nil {
 		t.Fatalf("got error from regexp.MatchString, got=%q, err=%v", got, err)

--- a/example_test.go
+++ b/example_test.go
@@ -64,7 +64,7 @@ func ExampleLTSVLogger_Err() {
 	}
 
 	// Output example:
-	// time:2017-06-10T13:40:38.344079Z	level:Error	err:add explanation here, err=some error	key1:value1	stack:[main.main.func1(0xc420041f48, 0x40e038) /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/err/main.go:12 +0x170],[main.main.func2(0x4ae320, 0xc42000e2a0) /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/err/main.go:15 +0x2a],[main.main() /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/err/main.go:24 +0x65]	key2:value2
+	// time:2017-06-10T13:40:38.344079Z	level:Error	err:add explanation here, err=some error	key1:value1	stack:main.main.func1 /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/err/main.go:12,main.main.func2 /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/err/main.go:15,main.main /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/err/main.go:24,runtime.main /usr/local/go/src/runtime/proc.go:194,runtime.goexit /usr/local/go/src/runtime/asm_amd64.s:2338	key2:value2
 	// Output:
 
 	// Actually we don't test the results.

--- a/example_test.go
+++ b/example_test.go
@@ -64,7 +64,7 @@ func ExampleLTSVLogger_Err() {
 	}
 
 	// Output example:
-	// time:2017-06-10T13:40:38.344079Z	level:Error	err:add explanation here, err=some error	key1:value1	stack:main.main.func1 /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/err/main.go:12,main.main.func2 /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/err/main.go:15,main.main /home/hnakamur/go/src/github.com/hnakamur/ltsvlog/example/err/main.go:24,runtime.main /usr/local/go/src/runtime/proc.go:194,runtime.goexit /usr/local/go/src/runtime/asm_amd64.s:2338	key2:value2
+	// time:2017-06-10T13:40:38.344079Z	level:Error	err:add explanation here, err=some error	key1:value1	stack:main.main.func1 github.com/hnakamur/ltsvlog/example/err/main.go:12,main.main.func2 github.com/hnakamur/ltsvlog/example/err/main.go:15,main.main github.com/hnakamur/ltsvlog/example/err/main.go:24,runtime.main runtime/proc.go:194,runtime.goexit runtime/asm_amd64.s:2338	key2:value2
 	// Output:
 
 	// Actually we don't test the results.


### PR DESCRIPTION
Change stacktrace format and optimize generating stacktraces.

```
$ benchstat old.log new.log
name                      old time/op    new time/op    delta
ErrWithStackAndUTCTime-2    21.9µs ± 7%    16.8µs ± 3%  -23.24%  (p=0.000 n=9+10)
ErrWithStack-2              20.8µs ± 3%    16.1µs ± 4%  -22.82%  (p=0.000 n=10+10)

name                      old alloc/op   new alloc/op   delta
ErrWithStackAndUTCTime-2    16.6kB ± 0%    16.5kB ± 0%   -0.55%  (p=0.000 n=10+10)
ErrWithStack-2              16.6kB ± 0%    16.5kB ± 0%   -0.57%  (p=0.000 n=10+10)

name                      old allocs/op  new allocs/op  delta
ErrWithStackAndUTCTime-2      5.00 ± 0%      4.00 ± 0%  -20.00%  (p=0.000 n=10+10)
ErrWithStack-2                5.00 ± 0%      4.00 ± 0%  -20.00%  (p=0.000 n=10+10)
```